### PR TITLE
fix: wrong color codeblock in light theme

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -53,7 +53,7 @@ pre.highlight  code{
     }
 
     .prose :where(code):not(:where([class~="not-prose"] *)) {
-        @apply bg-gray-300 dark:bg-gray-900 dark:text-gray-300 text-gray-800 py-1 px-2 rounded font-normal;
+        @apply bg-gray-300 dark:bg-gray-900 dark:text-gray-300 text-gray-100 py-1 px-2 rounded font-normal;
     }
 
     .sect1 + #footnotes {


### PR DESCRIPTION
## Summary

Fix color of text in codeblocks in light theme when the type (e.g. text, properties) is not supported by `highlight.js`

## Reference related issues

No related issues

## Closes

Closes #3 